### PR TITLE
Type Script files now detected with corrected file extension

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -161,9 +161,9 @@ function readCollectionFromJsJson(file) {
 }
 
 function isSupportedExt(ext) {
-  return ['.json', 'ts', '.js'].indexOf(ext) > -1;
+  return ['.json', '.ts', '.js'].indexOf(ext) > -1;
 }
 
 function isScript(name, ext) {
-  return name.endsWith('_') && ['ts', '.js'].indexOf(ext) > -1;
+  return name.endsWith('_') && ['.ts', '.js'].indexOf(ext) > -1;
 }


### PR DESCRIPTION
Using TypeScript files to hold fixtures data without their compiling are not detected because we are missing a fullstop int the extension