### PR TITLE
Allowing for the loading of specific fixtures

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ The following example will load the example fixtures into a locally running Mong
 ### Run
 
 1. `git clone https://github.com/cdimascio/node-mongodb-fixtures && cd node-mongodb-fixtures && npm install`
-- `bin/mongodb-fixtures load -u mongodb://localhost:27017/mydb --path ./examples/fixtures`
+- `node bin/mongodb-fixtures load -u mongodb://localhost:27017/mydb --path ./examples/fixtures`
 
 ---
 
@@ -152,6 +152,16 @@ const Fixtures = require('node-mongodb-fixtures');
 const fixtures = new Fixtures({
   dir: 'examples/fixtures',
   mute: false, // do not mute the log output
+});
+```
+
+or filter the fixtures present in the directory with a Regex pattern
+
+```javascript
+const Fixtures = require('node-mongodb-fixtures');
+const fixtures = new Fixtures({
+  dir: 'examples/fixtures',
+  filter: 'people.*'
 });
 ```
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ The following example will load the example fixtures into a locally running Mong
 ### Run
 
 1. `git clone https://github.com/cdimascio/node-mongodb-fixtures && cd node-mongodb-fixtures && npm install`
-- `bin/mongodb-fixtures load -u mongodb://localhost:27017/mydb --path ./examples/fixtures`
+- `node bin/mongodb-fixtures load -u mongodb://localhost:27017/mydb --path ./examples/fixtures`
 
 ---
 
@@ -155,6 +155,16 @@ const fixtures = new Fixtures({
 });
 ```
 
+or filter the fixtures present in the directory with a Regex pattern
+
+```javascript
+const Fixtures = require('node-mongodb-fixtures');
+const fixtures = new Fixtures({
+  dir: 'examples/fixtures',
+  filter: 'people.*'
+});
+```
+
 ### Connect
 
 Use the standard MongoDB [URI connection scheme](https://docs.mongodb.com/manual/reference/connection-string/)
@@ -231,9 +241,10 @@ fixtures
     -u --url <url>        mongo connection string
     -s --ssl              use SSL
     -d --db_name <name>   database name
-    -n --ssl_novlidate    use SSL with no verification
+    -n --ssl_novalidate   use SSL with no verification
     -c --ssl_ca </path/to/cert>  path to cert
     -p --path <path>      resource path. Default ./fixtures
+    -f --filter <pattern> regex pattern to filter fixture names
     -b --verbose          verbose logs
     -h, --help            output usage information
 

--- a/bin/mongodb-fixtures.js
+++ b/bin/mongodb-fixtures.js
@@ -28,9 +28,10 @@ program
   .option('-u --url <url>', 'mongo connection string')
   .option('-s --ssl', 'use SSL', false)
   .option('-d --db_name <name>', 'database name', false)
-  .option('-n --ssl_novlidate', 'use SSL with no verification', false)
+  .option('-n --ssl_novalidate', 'use SSL with no verification', false)
   .option('-c --ssl_ca <path/to/cert>', 'path to cert', false)
   .option('-p --path <path>', 'resource path. Default ./' + DEFAULT_PATH, false)
+  .option('-f --filter <pattern>', 'regex pattern to filter fixture names', false)
   .option('-b --verbose', 'verbose logs', false);
 
 program.parse(process.argv);
@@ -51,6 +52,7 @@ function main(opts) {
   const command = opts.command;
   const program = opts.program;
   const dir = opts.dir;
+  const filter = program.filter;
 
   const uri = program.url;
   const dbName = program.db_name;
@@ -70,7 +72,7 @@ function main(opts) {
     // mongoOptions.sslCA = [new Buffer(program.ssl_ca, 'base64')];
   }
 
-  const fixtures = new Fixtures({ dir: dir });
+  const fixtures = new Fixtures({ dir: dir, filter: filter });
 
   switch (command) {
     case 'load':

--- a/lib/index.js
+++ b/lib/index.js
@@ -18,7 +18,9 @@ function Fixtures(options) {
   options = options || {};
   this._mute = options.mute || false;
   this._dir = options.dir || 'fixtures';
+  this._match = options.filter ? new RegExp(options.filter) : null;
   log(this._mute, '[info ] Using fixtures directory: ' + this._dir);
+  if(this._match === null) log(this._mute, '[info ] No filtering in use');
   this._scripts = [];
 }
 
@@ -37,50 +39,57 @@ Fixtures.prototype.load = function() {
   assert(this._db, 'must call connect');
   return readdir(this._dir)
     .then(files => {
-      const promises = files.map(file => {
-        const parse = path.parse(file);
-        const ext = parse.ext.toLowerCase();
-        const collectionName = parse.name;
+      const promises = files
+        .filter(file => {
+          if(this._match === null) return true;
+          const matched = this._match.test(file);
+          log(this._mute, '[info ] Filter "' + this._match.source + '" ' + (matched ? 'matches' : 'excludes') + ' fixture: ' + file);
+          return matched;
+        })
+        .map(file => {
+          const parse = path.parse(file);
+          const ext = parse.ext.toLowerCase();
+          const collectionName = parse.name;
 
-        if (!isSupportedExt(ext)) {
-          return null;
-        } else if (isScript(collectionName, ext)) {
-          const filePath = path.join(this._dir, file);
-          return this._scripts.push(filePath);
-        }
+          if (!isSupportedExt(ext)) {
+            return null;
+          } else if (isScript(collectionName, ext)) {
+            const filePath = path.join(this._dir, file);
+            return this._scripts.push(filePath);
+          }
 
-        return readCollectionFromJsJson(path.join(this._dir, file))
-          .tap(() => log(this._mute, '[start] load', collectionName))
-          .then(docs => {
-            if (!Array.isArray(docs)) {
-              throw new Error(
-                '[error] no docs returned from file: "' +
-                  file +
-                  '". verify that a docs array was exported. note: if using .js files, use "module.exports", instead of "exports".'
-              );
-            }
-            return Promise.resolve(this._db.collection(collectionName)).then(
-              collection => {
-                const batch = collection.initializeUnorderedBulkOp();
-                docs.forEach(doc => batch.insert(doc));
-                if (batch.length === 0) {
-                  return {
-                    ok: true,
-                    message: '[done] ' + collectionName + ' load not required',
-                  };
-                }
-                return batch
-                  .execute()
-                  .tap(() => log(this._mute, '[done] load', collectionName))
-                  .tapCatch(e =>
-                    console.error('[error]', collectionName, e.message)
-                  );
+          return readCollectionFromJsJson(path.join(this._dir, file))
+            .tap(() => log(this._mute, '[start] load', collectionName))
+            .then(docs => {
+              if (!Array.isArray(docs)) {
+                throw new Error(
+                  '[error] no docs returned from file: "' +
+                    file +
+                    '". verify that a docs array was exported. note: if using .js files, use "module.exports", instead of "exports".'
+                );
               }
-            );
-          });
-      });
+              return Promise.resolve(this._db.collection(collectionName)).then(
+                collection => {
+                  const batch = collection.initializeUnorderedBulkOp();
+                  docs.forEach(doc => batch.insert(doc));
+                  if (batch.length === 0) {
+                    return {
+                      ok: true,
+                      message: '[done ] ' + collectionName + ' load not required',
+                    };
+                  }
+                  return batch
+                    .execute()
+                    .tap(() => log(this._mute, '[done ] load', collectionName))
+                    .tapCatch(e =>
+                      console.error('[error]', collectionName, e.message)
+                    );
+                }
+              );
+            });
+        });
       return Promise.all(promises).tap(() =>
-        log(this._mute, '[done] *load all')
+        log(this._mute, '[done ] *load all')
       );
     })
     .then(() => runScripts(this._db, this._scripts, this._mute))
@@ -105,13 +114,13 @@ Fixtures.prototype.unload = function() {
       return this._db
         .collection(collectionName)
         .deleteMany()
-        .tap(() => log(this._mute, '[done] unload', collectionName))
+        .tap(() => log(this._mute, '[done ] unload', collectionName))
         .tapCatch(e =>
           log(this._mute, '[error] unload', collectionName, e.message)
         );
     });
     return Promise.all(promises)
-      .tap(() => log(this._mute, '[done] *unload all'))
+      .tap(() => log(this._mute, '[done ] *unload all'))
       .then(() => this);
   });
 };
@@ -139,12 +148,12 @@ function runScripts(db, scripts, mute) {
         return Promise.reject('[error] script', base, 'must return a promise');
       }
       return r.then(r => {
-        log(mute, '[done] script', base);
+        log(mute, '[done ] script', base);
         return r;
       });
     });
   });
-  return Promise.all(promises).tap(() => log(mute, '[done] *script all'));
+  return Promise.all(promises).tap(() => log(mute, '[done ] *script all'));
 }
 
 function readCollectionFromJsJson(file) {


### PR DESCRIPTION
Hello
I am needing to be able to load just specific collections for certain unit tests.
Separating each fixture into a separate directory is not a good fit for our projects, I am looking to introduce a new option to allow the filtering  `--filter` of which fixtures are to be loaded.
How is my implementation? I jumped straight in, to work out what needed to be done.

I chose a Regex match, for simplicity sake. Globbing might have been nicer but was concerned how this fit with the exiting `--path` option.

Also, spotted a typo on `--ssl_novalidate`.