### PR TITLE
fix(method to delete collection): change drop() function to deleteMan…

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -92,7 +92,7 @@ Fixtures.prototype.unload = function() {
 
       const dropCollection = this._db
         .collection(collectionName)
-        .drop()
+        .deleteMany()
         .tap(() => log(this._mute, '[done ] unload', collectionName))
         .catch(e => {
           if (e.code !== 26) throw e;


### PR DESCRIPTION
…y() function

According the documentation of mongodb package drop() function is deprecated and will be replace by
deleteMany() function. Drop function causes some failures due to concurrent background task on
mongodb : "MongoError: cannot perform operation: a background operation is currently running for
collection .."